### PR TITLE
Update bufferhelper.js

### DIFF
--- a/lib/bufferhelper.js
+++ b/lib/bufferhelper.js
@@ -13,7 +13,7 @@ BufferHelper.prototype.empty = function () {
 };
 
 BufferHelper.prototype.toBuffer = function () {
-  return Buffer.concat(this.buffers);
+  return Buffer.concat(this.buffers, this.buffers.length);
 };
 
 BufferHelper.prototype.toString = function (encoding) {


### PR DESCRIPTION
Refer to: http://nodejs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength

> If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
