### PR TITLE
修复获取文本长度错误

### DIFF
--- a/lib/bufferhelper.js
+++ b/lib/bufferhelper.js
@@ -10,7 +10,7 @@ var BufferHelper = function () {
 
 BufferHelper.prototype.concat = function (buffer) {
   this.buffers.push(buffer);
-  this.size += buffer.length;
+  this.size += Buffer.byteLength(chunk);
   return this;
 };
 

--- a/lib/bufferhelper.js
+++ b/lib/bufferhelper.js
@@ -10,7 +10,7 @@ var BufferHelper = function () {
 
 BufferHelper.prototype.concat = function (buffer) {
   this.buffers.push(buffer);
-  this.size += Buffer.byteLength(chunk);
+  this.size += Buffer.byteLength(buffer);
   return this;
 };
 


### PR DESCRIPTION
一个中文的length的长度为1，但是buffer是使用的字节，会出现获取长度不精确